### PR TITLE
Cleanup of unused stuff

### DIFF
--- a/STM32/cores/arduino/stm32/SerialUSB.h
+++ b/STM32/cores/arduino/stm32/SerialUSB.h
@@ -89,8 +89,6 @@ class SerialUSBClass : public Stream{
       volatile uint16_t iTail;
     };
     ring_buffer rx_buffer;
-    //ring_buffer tx_buffer;
-    GPIO_InitTypeDef GPIO_InitStruct;
 };
 
 extern SerialUSBClass SerialUSB;


### PR DESCRIPTION
Just a simple cleanup. GPIO_InitStruct seems to be unused in SerialUSB