### PR TITLE
Fixing I2C initialization issue

### DIFF
--- a/STM32/cores/arduino/stm32/stm32_gpio_af.c
+++ b/STM32/cores/arduino/stm32/stm32_gpio_af.c
@@ -107,8 +107,8 @@ void stm32AfI2CInit(const I2C_TypeDef *instance,
     GPIO_TypeDef *sdaPort, uint32_t sdaPin,
     GPIO_TypeDef *sclPort, uint32_t sclPin) {
 
-    stm32AfInit(chip_af_i2c_sda, sizeof(chip_af_i2c_sda) / sizeof(chip_af_i2c_sda[0]), instance, sdaPort, sdaPin, GPIO_MODE_AF_OD, GPIO_PULLUP);
     stm32AfInit(chip_af_i2c_scl, sizeof(chip_af_i2c_scl) / sizeof(chip_af_i2c_scl[0]), instance, sclPort, sclPin, GPIO_MODE_AF_OD, GPIO_PULLUP);
+    stm32AfInit(chip_af_i2c_sda, sizeof(chip_af_i2c_sda) / sizeof(chip_af_i2c_sda[0]), instance, sdaPort, sdaPin, GPIO_MODE_AF_OD, GPIO_PULLUP);
 }
 
 #ifdef STM32_CHIP_HAS_SDIO

--- a/STM32/libraries/Wire/src/Wire.cpp
+++ b/STM32/libraries/Wire/src/Wire.cpp
@@ -57,7 +57,7 @@ void TwoWire::begin(void) {
     handle.Init.GeneralCallMode = I2C_GENERALCALL_DISABLE;
     handle.Init.NoStretchMode = I2C_NOSTRETCH_DISABLE;
 
-    setClock(100000);
+    setClock(400000);
 }
 
 void TwoWire::begin(uint8_t address) {
@@ -106,7 +106,7 @@ void TwoWire::begin(uint8_t address) {
     handle.Init.GeneralCallMode = I2C_GENERALCALL_DISABLE;
     handle.Init.NoStretchMode = I2C_NOSTRETCH_DISABLE;
 
-    setClock(100000);
+    setClock(400000);
     HAL_I2C_Slave_Receive_IT(&handle, &slaveBuffer, 1);
 
     //TODO rewrite IRQ handling to not use HAL_I2C_EV_IRQHandler, so F1 can also work

--- a/STM32/system/STM32F1/HAL_Inc/stm32f1xx_hal_i2c.h
+++ b/STM32/system/STM32F1/HAL_Inc/stm32f1xx_hal_i2c.h
@@ -205,7 +205,7 @@ typedef struct
 /** @defgroup I2C_addressing_mode I2C addressing mode
   * @{
   */
-#define I2C_ADDRESSINGMODE_7BIT         ((uint32_t)0x00004000)
+#define I2C_ADDRESSINGMODE_7BIT         ((uint32_t)0x00000000)
 #define I2C_ADDRESSINGMODE_10BIT        (I2C_OAR1_ADDMODE | ((uint32_t)0x00004000))
 /**
   * @}

--- a/STM32/system/STM32F1/HAL_Inc/stm32f1xx_hal_i2c.h
+++ b/STM32/system/STM32F1/HAL_Inc/stm32f1xx_hal_i2c.h
@@ -205,7 +205,7 @@ typedef struct
 /** @defgroup I2C_addressing_mode I2C addressing mode
   * @{
   */
-#define I2C_ADDRESSINGMODE_7BIT         ((uint32_t)0x00000000)
+#define I2C_ADDRESSINGMODE_7BIT         ((uint32_t)0x00004000)
 #define I2C_ADDRESSINGMODE_10BIT        (I2C_OAR1_ADDMODE | ((uint32_t)0x00004000))
 /**
   * @}


### PR DESCRIPTION
I hit interesting bug in I2C initialization. For some reason HAL_GPIO_Init() and therefore stm32AfInit() pulls pin value down to 0. I have not found an explanation in HAL documentation, but digitalRead() before and after confirms this fact.

The problem is that pulling SDA low while SCL is high means start condition on I2C bus. As result microcontroller (at least my STM32F103CB) can't initialize I2C - the periperhal get constantly busy and there is no way to reset it.

The solution is pretty simple - initialize pins in reverse order. 

BTW, stm32duino/libmaple go even further, they explicitely reset the bus by sending fake start and stop conditions. STM32GENERIC can reuse this idea at some point.

As for other changes. I changed I2C speed from 100kHz to 400 kHz. This is optional change, but improved performance on my SSD1306 display. This change is optional