### PR TITLE
Fixing alignment linker warning

### DIFF
--- a/STM32/libraries/FreeRTOS/src/port_CM3.c
+++ b/STM32/libraries/FreeRTOS/src/port_CM3.c
@@ -263,7 +263,7 @@ void vPortSVCHandler( void )
 					"	orr r14, #0xd					\n"
 					"	bx r14							\n"
 					"									\n"
-					"	.align 4						\n"
+					"	.align 2						\n"
 					"pxCurrentTCBConst2: .word pxCurrentTCB				\n"
 				);
 }
@@ -430,7 +430,7 @@ void xPortPendSVHandler( void )
 	"	isb									\n"
 	"	bx r14								\n"
 	"										\n"
-	"	.align 4							\n"
+	"	.align 2							\n"
 	"pxCurrentTCBConst: .word pxCurrentTCB	\n"
 	::"i"(configMAX_SYSCALL_INTERRUPT_PRIORITY)
 	);


### PR DESCRIPTION
I am linking with -Wl,--warn-section-align linker switch. When I added FreeRTOS to my project I got this warning


`ld.exe: warning: changing start of section .text by 4 bytes`

I know this code came from FreeRTOS without any modifications, but I took a look at the same code in stm32duino uses other alignment and does not generates the warning. Fix works fine on STM32F103