### PR TITLE
Added guard ifdef around F4 VECT_TAB_OFFSET definition

### DIFF
--- a/STM32/system/STM32F4/HAL_Src/system_stm32f4xx.c
+++ b/STM32/system/STM32F4/HAL_Src/system_stm32f4xx.c
@@ -108,8 +108,10 @@
 /*!< Uncomment the following line if you need to relocate your vector Table in
      Internal SRAM. */
 /* #define VECT_TAB_SRAM */
+#ifndef VECT_TAB_OFFSET
 #define VECT_TAB_OFFSET  0x00 /*!< Vector Table base offset field. 
                                    This value must be a multiple of 0x200. */
+#endif
 /******************************************************************************/
 
 /**


### PR DESCRIPTION
This was added so that the F4 sketch start address can be changed for use with a bootloader