### PR TITLE
Update boards.txt

### DIFF
--- a/STM32/boards.txt
+++ b/STM32/boards.txt
@@ -677,7 +677,7 @@ DISCOVERY_F407VG.menu.serial.SerialUART2.build.extra_flags_serial=-DMENU_SERIAL=
 ################################################################################
 # Discovery F429ZI board
 
-DISCOVERY_F429ZI.name = Discovery F429ZI
+DISCOVERY_F429ZI.name=Discovery F429ZI
 
 # TBD: correct memory settings here and in ldscript !!
 DISCOVERY_F429ZI.upload.maximum_size=1048576


### PR DESCRIPTION
Discovery F429ZI board is shown in VSCode+Extension4Arduino as "undefined", because of this spaces.
If i remove them, then it's shown as "Discovery F429ZI" and not as "undefined".

https://github.com/danieleff/STM32GENERIC/issues/45