### PR TITLE
Add method availabeForWrite in SerialUART

### DIFF
--- a/STM32/cores/arduino/stm32/SerialUART.cpp
+++ b/STM32/cores/arduino/stm32/SerialUART.cpp
@@ -174,6 +174,11 @@ void SerialUART::begin(const uint32_t baud) {
 int SerialUART::available() {
     return rxEnd != rxStart;
 }
+
+int SerialUART::availableForWrite() {
+    return txEnd != txStart;
+}
+
 int SerialUART::peek() {
     if (available()) {
     return rxBuffer[rxStart % BUFFER_SIZE];

--- a/STM32/cores/arduino/stm32/SerialUART.h
+++ b/STM32/cores/arduino/stm32/SerialUART.h
@@ -35,6 +35,7 @@ class SerialUART : public Stream  {
     void begin(const uint32_t baud);
     void end(void);
     int available(void);
+    int availableForWrite(void);
     int peek(void);
     int read(void);
     void flush(void);


### PR DESCRIPTION
This method is default in another adruino board addons.