### PR TITLE
Update Wire.cpp

### DIFF
--- a/STM32/libraries/Wire/src/Wire.cpp
+++ b/STM32/libraries/Wire/src/Wire.cpp
@@ -4,10 +4,8 @@
 #include "stm32_gpio_af.h"
 #include <Arduino.h>
 
-#ifndef I2C1_EV_IRQn
+#if defined(STM32F0)||defined(STM32L0)  /*F0/L0*/
 #define I2C1_EV_IRQn I2C1_IRQn
-#endif
-#ifndef I2C2_EV_IRQn
 #define I2C2_EV_IRQn I2C1_IRQn
 #endif
 


### PR DESCRIPTION
I2C doesn't compile for any board (except F0 & L0 probably):
You cannot check #ifndef I2C1_EV_IRQn, because I2C1_EV_IRQn is enum not #define.

The same for #ifndef I2C2_EV_IRQn.