### PR TITLE
Actually call setupUSB. SetupUSB is intended to give variants a chanc…

### DIFF
--- a/STM32/cores/arduino/main.cpp
+++ b/STM32/cores/arduino/main.cpp
@@ -56,7 +56,7 @@ int main(void)
     #endif
 
     #if defined(USB_BASE) || defined(USB_OTG_DEVICE_BASE)
-
+        void setupUSB();
     #ifdef MENU_USB_SERIAL
         USBDeviceFS.beginCDC();
     #elif MENU_USB_MASS_STORAGE
@@ -64,12 +64,12 @@ int main(void)
     #endif
 
     #endif
-	
+
 	setup();
-    
+
 	for (;;) {
 		loop();
 	}
-        
+
 	return 0;
 }


### PR DESCRIPTION
setupUSB is never called, so for variants which need to do pre-usb initialization, it doesn't work.