### PR TITLE
Call SetupUSB

### DIFF
--- a/STM32/cores/arduino/main.cpp
+++ b/STM32/cores/arduino/main.cpp
@@ -56,7 +56,7 @@ int main(void)
     #endif
 
     #if defined(USB_BASE) || defined(USB_OTG_DEVICE_BASE)
-
+        setupUSB();
     #ifdef MENU_USB_SERIAL
         USBDeviceFS.beginCDC();
     #elif MENU_USB_MASS_STORAGE
@@ -64,12 +64,12 @@ int main(void)
     #endif
 
     #endif
-	
+
 	setup();
-    
+
 	for (;;) {
 		loop();
 	}
-        
+
 	return 0;
 }

--- a/STM32/cores/arduino/main.cpp
+++ b/STM32/cores/arduino/main.cpp
@@ -56,7 +56,7 @@ int main(void)
     #endif
 
     #if defined(USB_BASE) || defined(USB_OTG_DEVICE_BASE)
-
+        void setupUSB();
     #ifdef MENU_USB_SERIAL
         USBDeviceFS.beginCDC();
     #elif MENU_USB_MASS_STORAGE
@@ -64,12 +64,12 @@ int main(void)
     #endif
 
     #endif
-	
+
 	setup();
-    
+
 	for (;;) {
 		loop();
 	}
-        
+
 	return 0;
 }


### PR DESCRIPTION
SetupUSB should allow variants to do system specific configuration for USB before it's initialized. The function exists but wasn't called, so if a variant overrides it, nothing happens.