### PR TITLE
Compatibility for Arduino Libraries and DMA Library to support ADC on STM32F4 

### DIFF
--- a/STM32/cores/arduino/avr/pgmspace.h
+++ b/STM32/cores/arduino/avr/pgmspace.h
@@ -41,4 +41,24 @@ typedef uint32_t prog_uint32_t;
 #define pgm_read_dword_far(addr) pgm_read_dword(addr)
 #define pgm_read_float_far(addr) pgm_read_float(addr)
 
+#define memcmp_P      memcmp
+#define memccpy_P     memccpy
+#define memmem_P      memmem
+#define memcpy_P      memcpy
+#define strcpy_P      strcpy
+#define strncpy_P     strncpy
+#define strcat_P      strcat
+#define strncat_P     strncat
+#define strcmp_P      strcmp
+#define strncmp_P     strncmp
+#define strcasecmp_P  strcasecmp
+#define strncasecmp_P strncasecmp
+#define strlen_P      strlen
+#define strnlen_P     strnlen
+#define strstr_P      strstr
+#define printf_P      printf
+#define sprintf_P     sprintf
+#define snprintf_P    snprintf
+#define vsnprintf_P   vsnprintf
+
 #endif

--- a/STM32/libraries/stm32_dma/src/stm32_dma.h
+++ b/STM32/libraries/stm32_dma/src/stm32_dma.h
@@ -26,7 +26,7 @@
 #include "stdbool.h"
 
 typedef enum {
-    SPI_TX, SPI_RX, SDIO_RXTX
+    SPI_TX, SPI_RX, SDIO_RXTX, ADC_DMA
 } dmaRequest;
 
 

--- a/STM32/libraries/stm32_dma/src/stm32_dma_F0F1F3L1.h
+++ b/STM32/libraries/stm32_dma/src/stm32_dma_F0F1F3L1.h
@@ -5,6 +5,7 @@
 // F3 RM0316 http://www.st.com/content/ccc/resource/technical/document/reference_manual/4a/19/6e/18/9d/92/43/32/DM00043574.pdf/files/DM00043574.pdf/jcr:content/translations/en.DM00043574.pdf#page=272
 // L1 RM0038 http://www.st.com/content/ccc/resource/technical/document/reference_manual/cc/f9/93/b2/f0/82/42/57/CD00240193.pdf/files/CD00240193.pdf/jcr:content/translations/en.CD00240193.pdf#page=255
 
+//These works just for L0 and F0, not for F1 (cannot compile) -> TO CHECK
 #ifndef DMA1_Channel2_IRQn
 #define DMA1_Channel2_IRQn DMA1_Channel2_3_IRQn
 #define DMA1_Channel3_IRQn DMA1_Channel2_3_IRQn
@@ -30,6 +31,8 @@ const dma_request_to_instance_t dmaRequestToStream[] = {
 
     {SPI1, SPI_TX, DMA1_Channel3, 3, DMA1_Channel3_IRQn},
     {SPI1, SPI_RX, DMA1_Channel2, 2, DMA1_Channel2_IRQn},
+    
+    {ADC1, ADC_DMA, DMA1_Channel1, 1, DMA1_Channel1_IRQn},
 
 #ifdef SPI2
     {SPI2, SPI_TX, DMA1_Channel5, 5, DMA1_Channel5_IRQn},

--- a/STM32/libraries/stm32_dma/src/stm32_dma_F2F4F7.h
+++ b/STM32/libraries/stm32_dma/src/stm32_dma_F2F4F7.h
@@ -26,6 +26,15 @@ const dma_request_to_instance_t dmaRequestToStream[] = {
     {SPI2, SPI_TX, DMA1_Stream4, DMA_CHANNEL_0, 4, DMA1_Stream4_IRQn},
     {SPI2, SPI_RX, DMA1_Stream3, DMA_CHANNEL_0, 3, DMA1_Stream3_IRQn},
 
+    {ADC1, ADC_DMA, DMA2_Stream0, DMA_CHANNEL_0, 0 + 8, DMA2_Stream0_IRQn},
+    {ADC1, ADC_DMA, DMA2_Stream4, DMA_CHANNEL_0, 4 + 8, DMA2_Stream4_IRQn},
+    
+    {ADC2, ADC_DMA, DMA2_Stream2, DMA_CHANNEL_1, 2 + 8, DMA2_Stream2_IRQn},
+    {ADC2, ADC_DMA, DMA2_Stream3, DMA_CHANNEL_1, 3 + 8, DMA2_Stream3_IRQn},
+    
+    {ADC3, ADC_DMA, DMA2_Stream0, DMA_CHANNEL_2, 0 + 8, DMA2_Stream0_IRQn},
+    {ADC3, ADC_DMA, DMA2_Stream1, DMA_CHANNEL_2, 1 + 8, DMA2_Stream1_IRQn},
+
 #ifdef SPI3
     {SPI3, SPI_TX, DMA1_Stream5, DMA_CHANNEL_0, 5, DMA1_Stream5_IRQn},
     {SPI3, SPI_RX, DMA1_Stream0, DMA_CHANNEL_0, 0, DMA1_Stream0_IRQn},

--- a/STM32/libraries/stm32_dma/src/stm32_dma_F2F4F7.h
+++ b/STM32/libraries/stm32_dma/src/stm32_dma_F2F4F7.h
@@ -28,13 +28,14 @@ const dma_request_to_instance_t dmaRequestToStream[] = {
 
     {ADC1, ADC_DMA, DMA2_Stream0, DMA_CHANNEL_0, 0 + 8, DMA2_Stream0_IRQn},
     {ADC1, ADC_DMA, DMA2_Stream4, DMA_CHANNEL_0, 4 + 8, DMA2_Stream4_IRQn},
-    
+#ifdef ADC2
     {ADC2, ADC_DMA, DMA2_Stream2, DMA_CHANNEL_1, 2 + 8, DMA2_Stream2_IRQn},
     {ADC2, ADC_DMA, DMA2_Stream3, DMA_CHANNEL_1, 3 + 8, DMA2_Stream3_IRQn},
-    
+#endif
+#ifdef ADC3
     {ADC3, ADC_DMA, DMA2_Stream0, DMA_CHANNEL_2, 0 + 8, DMA2_Stream0_IRQn},
     {ADC3, ADC_DMA, DMA2_Stream1, DMA_CHANNEL_2, 1 + 8, DMA2_Stream1_IRQn},
-
+#endif
 #ifdef SPI3
     {SPI3, SPI_TX, DMA1_Stream5, DMA_CHANNEL_0, 5, DMA1_Stream5_IRQn},
     {SPI3, SPI_RX, DMA1_Stream0, DMA_CHANNEL_0, 0, DMA1_Stream0_IRQn},


### PR DESCRIPTION
- Added STM32 corresponding functions to the ......_P Arduino functions for supporting Arduino Libraries.
- Added DMA configurations for ADC1,2,3 in stm32_dma Library.