### PR TITLE
Allow library integration, adding missing compiler.libraries.ldflags

### DIFF
--- a/STM32/boards.txt
+++ b/STM32/boards.txt
@@ -671,7 +671,8 @@ DISCOVERY_F407VG.upload.maximum_data_size=131072
 DISCOVERY_F407VG.build.core=arduino
 DISCOVERY_F407VG.build.board=DISCO_F407VG
 
-DISCOVERY_F407VG.build.mcu=cortex-m4 -mfpu=fpv4-sp-d16 -mfloat-abi=hard
+DISCOVERY_F407VG.build.mcu=cortex-m4
+DISCOVERY_F407VG.build.flags.fp=-mfpu=fpv4-sp-d16 -mfloat-abi=hard
 DISCOVERY_F407VG.build.series=STM32F4
 DISCOVERY_F407VG.build.variant=DISCOVERY_F407VG
 DISCOVERY_F407VG.build.extra_flags=-DSTM32F407VG -DHSE_VALUE=8000000

--- a/STM32/platform.txt
+++ b/STM32/platform.txt
@@ -48,6 +48,8 @@ compiler.ldflags=
 compiler.size.cmd=arm-none-eabi-size
 compiler.define=-DARDUINO=
 
+compiler.libraries.ldflags=
+
 # this can be overriden in boards.txt
 build.extra_flags=
 build.extra_flags_usb=
@@ -90,7 +92,7 @@ recipe.S.o.pattern="{compiler.path}{compiler.S.cmd}" {compiler.S.flags} -D{build
 recipe.ar.pattern="{compiler.path}{compiler.ar.cmd}" {compiler.ar.flags} {compiler.ar.extra_flags} "{archive_file_path}" "{object_file}"
 
 ## Combine gc-sections, archives, and objects
-recipe.c.combine.pattern="{compiler.path}{compiler.c.elf.cmd}" {compiler.c.elf.flags} "-T{build.variant.path}/{build.ldscript}" "-Wl,-Map,{build.path}/{build.project_name}.map" {compiler.c.elf.extra_flags} -o "{build.path}/{build.project_name}.elf" "-L{build.path}" -Wl,--start-group {object_files} "{build.path}/{archive_file}" -lc -Wl,--end-group -lm -lgcc --specs=nano.specs
+recipe.c.combine.pattern="{compiler.path}{compiler.c.elf.cmd}" {compiler.c.elf.flags} "-T{build.variant.path}/{build.ldscript}" "-Wl,-Map,{build.path}/{build.project_name}.map" {compiler.c.elf.extra_flags} -o "{build.path}/{build.project_name}.elf" "-L{build.path}" -Wl,--start-group {object_files} {compiler.libraries.ldflags} "{build.path}/{archive_file}" -lc -Wl,--end-group -lm -lgcc --specs=nano.specs
 
 ## Create output (.bin file)
 recipe.objcopy.bin.pattern="{compiler.path}{compiler.elf2hex.cmd}" {compiler.elf2hex.flags} {compiler.elf2hex.extra_flags} "{build.path}/{build.project_name}.elf" "{build.path}/{build.project_name}.bin"


### PR DESCRIPTION
compiler.libraries.ldflags was missing in the platform.txt. It is required to integrate libraries by the linking step.

In addition to that the .mcu setting of DISCOVERY_F407VG causes trouble.
"-mfpu=fpv4-sp-d16 -mfloat-abi=hard" is shifted now to flags.fp.